### PR TITLE
Array_keys() warning

### DIFF
--- a/src/twitter.class.php
+++ b/src/twitter.class.php
@@ -167,7 +167,7 @@ class Twitter
 	 * @return mixed
 	 * @throws TwitterException
 	 */
-	public function request($resource, $method, array $data = NULL)
+	public function request($resource, $method, array $data = array())
 	{
 		if (!strpos($resource, '://')) {
 			if (!strpos($resource, '.')) {


### PR DESCRIPTION
If you call request() without the 3rd parameter it throws the following warning:

<pre>Warning: array_keys() expects parameter 1 to be array, null given</pre>


So, $data needs to be an empty array(), not NULL.
