### PR TITLE
update self::API_URL to use HTTPS per docs

### DIFF
--- a/src/twitter.class.php
+++ b/src/twitter.class.php
@@ -15,7 +15,7 @@ require_once dirname(__FILE__) . '/OAuth.php';
  */
 class Twitter
 {
-	const API_URL = 'http://api.twitter.com/1.1/';
+	const API_URL = 'https://api.twitter.com/1.1/';
 
 	/**#@+ Timeline {@link Twitter::load()} */
 	const ME = 1;


### PR DESCRIPTION
I believe HTTPS is the correct endpoint, not HTTP.

The docs all use SSL in their examples, and POSTs often return 403 (in my tests) when not using SSL.
https://dev.twitter.com/docs/api/1.1
