### PR TITLE
Use secure Twitter API hook

### DIFF
--- a/src/twitter.class.php
+++ b/src/twitter.class.php
@@ -15,7 +15,7 @@ require_once dirname(__FILE__) . '/OAuth.php';
  */
 class Twitter
 {
-	const API_URL = 'http://api.twitter.com/1.1/';
+	const API_URL = 'https://api.twitter.com/1.1/';
 
 	/**#@+ Timeline {@link Twitter::load()} */
 	const ME = 1;


### PR DESCRIPTION
Per https://dev.twitter.com/discussions/24239, Twitter APIs now require SSL/TLS.  This patch aims to restore Twitter API connectivity.
