### PR TITLE
Change API_URL to use https because twitter api no longer accepts http r...

### DIFF
--- a/src/twitter.class.php
+++ b/src/twitter.class.php
@@ -15,7 +15,7 @@ require_once dirname(__FILE__) . '/OAuth.php';
  */
 class Twitter
 {
-	const API_URL = 'http://api.twitter.com/1.1/';
+	const API_URL = 'https://api.twitter.com/1.1/';
 
 	/**#@+ Timeline {@link Twitter::load()} */
 	const ME = 1;


### PR DESCRIPTION
...equests. See: https://dev.twitter.com/discussions/24239
