### PR TITLE
Update twitter.class.php

### DIFF
--- a/src/twitter.class.php
+++ b/src/twitter.class.php
@@ -253,7 +253,7 @@ class Twitter
 			throw new TwitterException('Server error: ' . curl_error($curl));
 		}
 
-		$payload = version_compare(PHP_VERSION, '5.4.0') >= 0 ?
+		$payload = (version_compare(PHP_VERSION, '5.4.0') >= 0 && defined('JSON_BIGINT_AS_STING')) ?
 			@json_decode($result, FALSE, 128, JSON_BIGINT_AS_STRING) : @json_decode($result); // intentionally @
 
 		if ($payload === FALSE) {


### PR DESCRIPTION
JSON_BIGINT_AS_STRING is not supported in some Linux packages.

https://bugs.php.net/bug.php?id=63520 defines the problem, and the new licence-compatible php library doesn't support this feature.

Change the call to check that the JSON_BIGINT_AS_STRING is defined before using it.  Fixed stock PHP (5.5.9~1) on Ubuntu 14.04 LTS.
