### PR TITLE
Fix Warning in HHVM

### DIFF
--- a/src/Twitter.php
+++ b/src/Twitter.php
@@ -252,13 +252,16 @@ class Twitter
 			CURLOPT_HEADER => FALSE,
 			CURLOPT_RETURNTRANSFER => TRUE,
 		) + ($method === 'POST' ? array(
-			$hasCURLFile ? CURLOPT_SAFE_UPLOAD : -1 => TRUE,
 			CURLOPT_POST => TRUE,
 			CURLOPT_POSTFIELDS => $files ? $data : $request->to_postdata(),
 			CURLOPT_URL => $files ? $request->to_url() : $request->get_normalized_http_url(),
 		) : array(
 			CURLOPT_URL => $request->to_url(),
 		)) + $this->httpOptions;
+
+		if ($method === 'POST' && $hasCURLFile) {
+			$options[CURLOPT_SAFE_UPLOAD] = TRUE;
+		}
 
 		$curl = curl_init();
 		curl_setopt_array($curl, $options);


### PR DESCRIPTION
Newest version of HHVM doesn't like the -1 workaround.
```
Warning: Invalid argument: option: -1 in /vendor/dg/twitter-php/src/Twitter.php on line 264
```