### PR TITLE
Check if cache file exists before attempting to use it

### DIFF
--- a/src/Twitter.php
+++ b/src/Twitter.php
@@ -309,10 +309,12 @@ class Twitter
 			. md5($resource . json_encode($data) . serialize(array($this->consumer, $this->token)))
 			. '.json';
 
-		$cache = @json_decode(@file_get_contents($cacheFile)); // intentionally @
-		$expiration = is_string($cacheExpire) ? strtotime($cacheExpire) - time() : $cacheExpire;
-		if ($cache && @filemtime($cacheFile) + $expiration > time()) { // intentionally @
-			return $cache;
+		if (file_exists($cacheFile)) {
+			$cache = json_decode(file_get_contents($cacheFile));
+			$expiration = is_string($cacheExpire) ? strtotime($cacheExpire) - time() : $cacheExpire;
+			if ($cache && filemtime($cacheFile) + $expiration > time()) {
+				return $cache;
+			}
 		}
 
 		try {


### PR DESCRIPTION
The `@` does not stop custom error handlers from picking up the error and dumping it into the logs. Our logs regularly have errors in them because twitter-php is trying to use a cache file that does not exist. We might be able to modify our error handler to distinguish swallowed errors (though from what I've read, it's hard to do) but to me it's better and more understandable to just check if the file exists before attempting to use it.