### PR TITLE
fix search not returning stdclass

### DIFF
--- a/src/Twitter.php
+++ b/src/Twitter.php
@@ -254,7 +254,7 @@ class Twitter
 	public function search($query, bool $full = false): stdClass
 	{
 		$res = $this->request('search/tweets', 'GET', is_array($query) ? $query : ['q' => $query]);
-		return $full ? $res : $res->statuses;
+		return (object)($full ? $res : $res->statuses);
 	}
 
 


### PR DESCRIPTION
Fix for

PHP Fatal error:  Uncaught TypeError: Return value of DG\Twitter\Twitter::search() must be an instance of stdClass, array returned in twitter-php/src/Twitter.php:257