### PR TITLE
Fix request for method Delete

### DIFF
--- a/src/Twitter.php
+++ b/src/Twitter.php
@@ -352,6 +352,8 @@ class Twitter
 				: "Server error #$code with answer $result",
 				$code
 			);
+		} else if($code == 204){
+			$payload = true;
 		}
 
 		return $payload;

--- a/src/Twitter.php
+++ b/src/Twitter.php
@@ -304,7 +304,7 @@ class Twitter
 			$data = json_encode($data);
 			$headers[] = 'Content-Type: application/json';
 
-		} elseif ($method === 'GET' && $data) {
+		} elseif (($method === 'GET' || $method === 'DELETE') && $data) {
 			$resource .= '?' . http_build_query($data, '', '&');
 		}
 


### PR DESCRIPTION
### Add http_build_query for method Delete
 Delete method always uses an id parameter, but previously adding parameters only included the GET method. 
 
### Fix return for method Delete
When the delete method is successful, it always returns an empty body, with an HTTP 204 code.

Source: 
[https://developer.twitter.com/en/docs/api-reference-index](URL)
[https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/delete-message-event](URL)

