### PR TITLE
Added headers methods, and RAW data var

### DIFF
--- a/src/Twitter.php
+++ b/src/Twitter.php
@@ -43,6 +43,12 @@ class Twitter
 		CURLOPT_USERAGENT => 'Twitter for PHP',
 	];
 
+	/** @var array */
+	public $headers;
+
+	/** @var string */
+	public $body;
+
 	/** @var OAuth\Consumer */
 	private $consumer;
 
@@ -312,9 +318,11 @@ class Twitter
 		$request->sign_request(new OAuth\SignatureMethod_HMAC_SHA1, $this->consumer, $this->token);
 		$headers[] = $request->to_header();
 
+		$this->headers = []; // Header array cleanup
+
 		$options = [
 			CURLOPT_URL => $resource,
-			CURLOPT_HEADER => false,
+			CURLOPT_HEADERFUNCTION => [$this, '_setHeader'],
 			CURLOPT_RETURNTRANSFER => true,
 			CURLOPT_HTTPHEADER => $headers,
 		] + $this->httpOptions;
@@ -338,6 +346,8 @@ class Twitter
 			throw new Exception('Server error: ' . curl_error($curl));
 		}
 
+		$this->body = $result; // RAW body
+		
 		if (strpos(curl_getinfo($curl, CURLINFO_CONTENT_TYPE), 'application/json') !== false) {
 			$payload = @json_decode($result, false, 128, JSON_BIGINT_AS_STRING); // intentionally @
 			if ($payload === false) {
@@ -431,6 +441,30 @@ class Twitter
 				. iconv_substr($s, $item[2], iconv_strlen($s, 'UTF-8'), 'UTF-8');
 		}
 		return $s;
+	}
+
+
+	/**
+	 * Saves headers to the instance
+	 */
+	private function _setHeader($ch, $header)
+	{
+		$this->headers[] = trim($header);
+		return strlen($header);
+	}
+
+	/**
+	 * Get headers in an indexed array
+	 */
+	public function getHeaderArray()
+	{
+		$headers_array = [];
+		foreach ($this->headers as $h) {
+			if(preg_match_all('/^([A-Za-z-]+)\: ([ -~]+)/', $h, $matches, PREG_SET_ORDER, 0)){
+				$headers_array[$matches[0][1]] = $matches[0][2];
+			}
+		}
+		return $headers_array;
 	}
 }
 


### PR DESCRIPTION
Some times you need to know your rate limiting, and the only way to know it is by reading this HTTP headers:

```text
x-rate-limit-limit
x-rate-limit-reset
x-rate-limit-remaining
```

So I added the method `_setHeader` to store the CURL received headers, and the `getHeaderArray` method to return an indexed array with the current HTTP headers **after any request**:

```php
$my_headers = $twitter->getHeaderArray();

$current_time = time();
$time_to_next = $my_headers['x-rate-limit-reset'] - $current_time;
if($tw_headers['x-rate-limit-remaining']<1){
	echo "Sleeping for ".$time_to_next." seconds, or ".($time_to_next/60)." minutes .\n";
	sleep($time_to_next);
}
```

I also added the public instance of the RAW body, for development and debugging purposes.