### PR TITLE
Add required id parameter to destroy function

### DIFF
--- a/src/Twitter.php
+++ b/src/Twitter.php
@@ -228,7 +228,7 @@ class Twitter
 	 */
 	public function destroy($id)
 	{
-		$res = $this->request("statuses/destroy/$id", 'POST');
+		$res = $this->request("statuses/destroy/$id", 'POST', ["id" => $id]);
 		return $res->id ?: false;
 	}
 


### PR DESCRIPTION
According to the Twitter documentation, the ID is required in the POST parameters.
https://developer.twitter.com/en/docs/twitter-api/v1/tweets/post-and-engage/api-reference/post-statuses-destroy-id