### PR TITLE
Method that retrieves an oauth Request Token for 3-legged authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+/.idea
 /vendor
 /composer.lock

--- a/examples/custom-request.php
+++ b/examples/custom-request.php
@@ -16,11 +16,11 @@ $statuses = $twitter->request('statuses/retweets_of_me', 'GET');
 <title>Twitter retweets of me</title>
 
 <ul>
-<?php foreach ($statuses as $status): ?>
+<?php foreach ($statuses as $status) { ?>
 	<li><a href="http://twitter.com/<?php echo $status->user->screen_name ?>"><img src="<?php echo htmlspecialchars($status->user->profile_image_url_https) ?>">
 		<?php echo htmlspecialchars($status->user->name) ?></a>:
 		<?php echo Twitter::clickable($status) ?>
 		<small>at <?php echo date('j.n.Y H:i', strtotime($status->created_at)) ?></small>
 	</li>
-<?php endforeach ?>
+<?php } ?>
 </ul>

--- a/examples/load.php
+++ b/examples/load.php
@@ -19,11 +19,11 @@ $statuses = $twitter->load(Twitter::ME_AND_FRIENDS);
 <title>Twitter timeline demo</title>
 
 <ul>
-<?php foreach ($statuses as $status): ?>
+<?php foreach ($statuses as $status) { ?>
 	<li><a href="https://twitter.com/<?php echo $status->user->screen_name ?>"><img src="<?php echo htmlspecialchars($status->user->profile_image_url_https) ?>">
 		<?php echo htmlspecialchars($status->user->name) ?></a>:
 		<?php echo Twitter::clickable($status) ?>
 		<small>at <?php echo date('j.n.Y H:i', strtotime($status->created_at)) ?></small>
 	</li>
-<?php endforeach ?>
+<?php } ?>
 </ul>

--- a/examples/search.php
+++ b/examples/search.php
@@ -16,11 +16,11 @@ $results = $twitter->search('#nette');
 <title>Twitter search demo</title>
 
 <ul>
-<?php foreach ($results as $status): ?>
+<?php foreach ($results as $status) { ?>
 	<li><a href="https://twitter.com/<?php echo $status->user->screen_name ?>"><img src="<?php echo htmlspecialchars($status->user->profile_image_url_https) ?>">
 		<?php echo htmlspecialchars($status->user->name) ?></a>:
 		<?php echo Twitter::clickable($status) ?>
 		<small>at <?php echo date('j.n.Y H:i', strtotime($status->created_at)) ?></small>
 	</li>
-<?php endforeach ?>
+<?php } ?>
 </ul>

--- a/readme.md
+++ b/readme.md
@@ -113,6 +113,27 @@ if (!$twitter->authenticate()) {
 }
 ```
 
+The `getRequestToken()` method allows a Consumer application to obtain an OAuth Request Token to request user authorization:
+ - Documentation/Use-Cases: https://developer.twitter.com/en/docs/authentication/api-reference/request_token
+ - Define a Callback URL in your Twitter Application (Required): https://developer.twitter.com/en/docs/apps/callback-urls
+```php
+# You can Initialize a new Twitter object using only the Consumer Key and Secret
+$this->twitter = new Twitter($consumerKey, $consumerSecret);
+# Call the getRequestToken() using the callback URL defined in your twitter application.
+$response = $this->twitter->getRequestToken('https://localhost.com/twitter-callback-url');
+```
+
+Example Response:
+
+```php 
+{
+    "oauth_token": "x-oFdAAAAAABVLnXXXXXXXX_XXX",
+    "oauth_token_secret": "A810fifujUZXXXXXXXXXXXXXXXXXXXXX",
+    "oauth_callback_confirmed": "true"
+}
+```
+
+
 Other commands
 --------------
 

--- a/readme.md
+++ b/readme.md
@@ -6,13 +6,21 @@
 Twitter for PHP is a very small and easy-to-use library for sending
 messages to Twitter and receiving status updates.
 
-If you like this, **[please make a donation now](https://nette.org/make-donation?to=twitter-php)**. Thank you!
-
 It requires PHP 5.4 or newer with CURL extension and is licensed under the New BSD License.
 You can obtain the latest version from our [GitHub repository](https://github.com/dg/twitter-php)
 or install it via Composer:
 
 	composer require dg/twitter-php
+
+
+[Support Me](https://github.com/sponsors/dg)
+--------------------------------------------
+
+Do you like Nette DI? Are you looking forward to the new features?
+
+[![Buy me a coffee](https://files.nette.org/icons/donation-3.svg)](https://github.com/sponsors/dg)
+
+Thank you!
 
 
 Usage

--- a/src/OAuth.php
+++ b/src/OAuth.php
@@ -302,12 +302,17 @@ class Request
 	/**
 	 * attempt to build up a request from what was passed to the server
 	 */
-	public static function from_request(string $http_method = null, string $http_url = null, array $parameters = null): self
-	{
+	public static function from_request(
+		string $http_method = null,
+		string $http_url = null,
+		array $parameters = null
+	): self {
 		$scheme = (!isset($_SERVER['HTTPS']) || $_SERVER['HTTPS'] != 'on')
 			? 'http'
 			: 'https';
-		$http_url = ($http_url) ? $http_url : $scheme .
+		$http_url = ($http_url)
+			? $http_url
+			: $scheme .
 			'://' . $_SERVER['HTTP_HOST'] .
 			':' .
 			$_SERVER['SERVER_PORT'] .
@@ -339,7 +344,10 @@ class Request
 
 			// We have a Authorization-header with OAuth data. Parse the header
 			// and add those overriding any duplicates from GET or POST
-			if (isset($request_headers['Authorization']) && substr($request_headers['Authorization'], 0, 6) == 'OAuth ') {
+			if (
+				isset($request_headers['Authorization'])
+				&& substr($request_headers['Authorization'], 0, 6) == 'OAuth '
+			) {
 				$header_parameters = Util::split_header(
 					$request_headers['Authorization']
 				);
@@ -354,8 +362,13 @@ class Request
 	/**
 	 * pretty much a helper function to set up the request
 	 */
-	public static function from_consumer_and_token(Consumer $consumer, ?Token $token, string $http_method, string $http_url, array $parameters = null): self
-	{
+	public static function from_consumer_and_token(
+		Consumer $consumer,
+		?Token $token,
+		string $http_method,
+		string $http_url,
+		array $parameters = null
+	): self {
 		$parameters = $parameters ?: [];
 		$defaults = [
 			'oauth_version' => self::$version,
@@ -392,7 +405,7 @@ class Request
 
 	public function get_parameter(string $name)
 	{
-		return isset($this->parameters[$name]) ? $this->parameters[$name] : null;
+		return $this->parameters[$name] ?? null;
 	}
 
 
@@ -465,7 +478,9 @@ class Request
 		$parts = parse_url($this->http_url);
 
 		$scheme = (isset($parts['scheme'])) ? $parts['scheme'] : 'http';
-		$port = (isset($parts['port'])) ? $parts['port'] : (($scheme == 'https') ? '443' : '80');
+		$port = (isset($parts['port']))
+			? $parts['port']
+			: (($scheme == 'https') ? '443' : '80');
 		$host = (isset($parts['host'])) ? $parts['host'] : '';
 		$path = (isset($parts['path'])) ? $parts['path'] : '';
 
@@ -581,7 +596,7 @@ class Util
 	public static function urlencode_rfc3986($input)
 	{
 		if (is_array($input)) {
-			return array_map([__CLASS__, 'urlencode_rfc3986'], $input);
+			return array_map([self::class, 'urlencode_rfc3986'], $input);
 		} elseif (is_scalar($input)) {
 			return str_replace('+', ' ', str_replace('%7E', '~', rawurlencode((string) $input)));
 		} else {

--- a/src/Twitter.php
+++ b/src/Twitter.php
@@ -14,9 +14,7 @@ declare(strict_types=1);
  */
 
 namespace DG\Twitter;
-
 use stdClass;
-
 
 /**
  * Twitter API.
@@ -49,7 +47,6 @@ class Twitter
 	/** @var OAuth\Token */
 	private $token;
 
-
 	/**
 	 * Creates object using consumer and access keys.
 	 * @throws Exception when CURL extension is not loaded
@@ -70,11 +67,12 @@ class Twitter
 		}
 	}
 
-
-	/**
-	 * Tests if user credentials are valid.
-	 * @throws Exception
-	 */
+    /**
+     * Tests if user credentials are valid.
+     * @return bool
+     * @throws Exception
+     * @throws OAuth\Exception
+     */
 	public function authenticate(): bool
 	{
 		try {
@@ -89,13 +87,16 @@ class Twitter
 		}
 	}
 
-
-	/**
-	 * Sends message to the Twitter.
-	 * https://dev.twitter.com/rest/reference/post/statuses/update
-	 * @param  string|array  $mediaPath  path to local media file to be uploaded
-	 * @throws Exception
-	 */
+    /**
+     * Sends message to the Twitter.
+     * https://dev.twitter.com/rest/reference/post/statuses/update
+     * @param string $message
+     * @param null $mediaPath path to local media file to be uploaded
+     * @param array $options
+     * @return stdClass
+     * @throws Exception
+     * @throws OAuth\Exception
+     */
 	public function send(string $message, $mediaPath = null, array $options = []): stdClass
 	{
 		$mediaIds = [];
@@ -115,12 +116,15 @@ class Twitter
 		);
 	}
 
-
-	/**
-	 * Sends a direct message to the specified user.
-	 * https://dev.twitter.com/rest/reference/post/direct_messages/new
-	 * @throws Exception
-	 */
+    /**
+     * Sends a direct message to the specified user.
+     * https://dev.twitter.com/rest/reference/post/direct_messages/new
+     * @param string $username
+     * @param string $message
+     * @return stdClass
+     * @throws Exception
+     * @throws OAuth\Exception
+     */
 	public function sendDirectMessage(string $username, string $message): stdClass
 	{
 		return $this->request(
@@ -136,25 +140,29 @@ class Twitter
 		);
 	}
 
-
-	/**
-	 * Follows a user on Twitter.
-	 * https://dev.twitter.com/rest/reference/post/friendships/create
-	 * @throws Exception
-	 */
+    /**
+     * Follows a user on Twitter.
+     * https://dev.twitter.com/rest/reference/post/friendships/create
+     * @param string $username
+     * @return stdClass
+     * @throws Exception
+     * @throws OAuth\Exception
+     */
 	public function follow(string $username): stdClass
 	{
 		return $this->request('friendships/create', 'POST', ['screen_name' => $username]);
 	}
 
-
-	/**
-	 * Returns the most recent statuses.
-	 * https://dev.twitter.com/rest/reference/get/statuses/user_timeline
-	 * @param  int  $flags  timeline (ME | ME_AND_FRIENDS | REPLIES) and optional (RETWEETS)
-	 * @return stdClass[]
-	 * @throws Exception
-	 */
+    /**
+     * Returns the most recent statuses.
+     * https://dev.twitter.com/rest/reference/get/statuses/user_timeline
+     * @param int $flags timeline (ME | ME_AND_FRIENDS | REPLIES) and optional (RETWEETS)
+     * @param int $count
+     * @param array|null $data
+     * @return stdClass[]
+     * @throws Exception
+     * @throws OAuth\Exception
+     */
 	public function load(int $flags = self::ME, int $count = 20, array $data = null): array
 	{
 		static $timelines = [
@@ -172,34 +180,43 @@ class Twitter
 		]);
 	}
 
-
-	/**
-	 * Returns information of a given user.
-	 * https://dev.twitter.com/rest/reference/get/users/show
-	 * @throws Exception
-	 */
+    /**
+     * Returns information of a given user.
+     * https://dev.twitter.com/rest/reference/get/users/show
+     * @param string $username
+     * @return stdClass
+     * @throws Exception
+     * @throws OAuth\Exception
+     */
 	public function loadUserInfo(string $username): stdClass
 	{
 		return $this->cachedRequest('users/show', ['screen_name' => $username]);
 	}
 
-
-	/**
-	 * Returns information of a given user by id.
-	 * https://dev.twitter.com/rest/reference/get/users/show
-	 * @throws Exception
-	 */
+    /**
+     * Returns information of a given user by id.
+     * https://dev.twitter.com/rest/reference/get/users/show
+     * @param string $id
+     * @return stdClass
+     * @throws Exception
+     * @throws OAuth\Exception
+     */
 	public function loadUserInfoById(string $id): stdClass
 	{
 		return $this->cachedRequest('users/show', ['user_id' => $id]);
 	}
 
-
-	/**
-	 * Returns IDs of followers of a given user.
-	 * https://dev.twitter.com/rest/reference/get/followers/ids
-	 * @throws Exception
-	 */
+    /**
+     * Returns IDs of followers of a given user.
+     * https://dev.twitter.com/rest/reference/get/followers/ids
+     * @param string $username
+     * @param int $count
+     * @param int $cursor
+     * @param null $cacheExpiry
+     * @return stdClass
+     * @throws Exception
+     * @throws OAuth\Exception
+     */
 	public function loadUserFollowers(
 		string $username,
 		int $count = 5000,
@@ -213,12 +230,17 @@ class Twitter
 		], $cacheExpiry);
 	}
 
-
-	/**
-	 * Returns list of followers of a given user.
-	 * https://dev.twitter.com/rest/reference/get/followers/list
-	 * @throws Exception
-	 */
+    /**
+     * Returns list of followers of a given user.
+     * https://dev.twitter.com/rest/reference/get/followers/list
+     * @param string $username
+     * @param int $count
+     * @param int $cursor
+     * @param null $cacheExpiry
+     * @return stdClass
+     * @throws Exception
+     * @throws OAuth\Exception
+     */
 	public function loadUserFollowersList(
 		string $username,
 		int $count = 200,
@@ -232,61 +254,69 @@ class Twitter
 		], $cacheExpiry);
 	}
 
-
-	/**
-	 * Destroys status.
-	 * @param  int|string  $id  status to be destroyed
-	 * @throws Exception
-	 */
+    /**
+     * Destroys status.
+     * @param int|string $id status to be destroyed
+     * @return false
+     * @throws Exception
+     * @throws OAuth\Exception
+     */
 	public function destroy($id)
 	{
 		$res = $this->request("statuses/destroy/$id", 'POST', ['id' => $id]);
 		return $res->id ?: false;
 	}
 
-
-	/**
-	 * Retrieves a single status.
-	 * @param  int|string  $id  status to be retrieved
-	 * @throws Exception
-	 */
+    /**
+     * Retrieves a single status.
+     * @param int|string $id status to be retrieved
+     * @return array|bool|mixed
+     * @throws Exception
+     * @throws OAuth\Exception
+     */
 	public function get($id)
 	{
 		$res = $this->request("statuses/show/$id", 'GET');
 		return $res;
 	}
 
-
-	/**
-	 * Returns tweets that match a specified query.
-	 * https://dev.twitter.com/rest/reference/get/search/tweets
-	 * @param  string|array
-	 * @throws Exception
-	 * @return stdClass|stdClass[]
-	 */
+    /**
+     * Returns tweets that match a specified query.
+     * https://dev.twitter.com/rest/reference/get/search/tweets
+     * @param string|array
+     * @param bool $full
+     * @return stdClass|stdClass[]
+     * @throws Exception
+     * @throws OAuth\Exception
+     */
 	public function search($query, bool $full = false)
 	{
 		$res = $this->request('search/tweets', 'GET', is_array($query) ? $query : ['q' => $query]);
 		return $full ? $res : $res->statuses;
 	}
 
-
-	/**
-	 * Retrieves the top 50 trending topics for a specific WOEID.
-	 * @param  int|string  $WOEID  Where On Earth IDentifier
-	 */
+    /**
+     * Retrieves the top 50 trending topics for a specific WOEID.
+     * @param int|string $WOEID Where On Earth IDentifier
+     * @return array
+     * @throws Exception
+     * @throws OAuth\Exception
+     */
 	public function getTrends(int $WOEID): array
 	{
 		return $this->request("trends/place.json?id=$WOEID", 'GET');
 	}
 
-
-	/**
-	 * Process HTTP request.
-	 * @param  string  $method  GET|POST|JSONPOST|DELETE
-	 * @return mixed
-	 * @throws Exception
-	 */
+    /**
+     * Process HTTP request.
+     * @param string $resource
+     * @param string $method GET|POST|JSONPOST|DELETE
+     * @param array $data
+     * @param array $files
+     * @return mixed
+     * @throws Exception
+     * @throws OAuth\Exception
+     */
 	public function request(string $resource, string $method, array $data = [], array $files = [])
 	{
 		if (!strpos($resource, '://')) {
@@ -345,19 +375,31 @@ class Twitter
 
 		$curl = curl_init();
 		curl_setopt_array($curl, $options);
+        /**
+         * The result of the request (Raw Body)
+         */
 		$result = curl_exec($curl);
+        /**
+         * Get the Content-Type from the Response;
+         */
+        $contentType = curl_getinfo($curl, CURLINFO_CONTENT_TYPE);
+        /**
+         * Get the Response Code from the Request.
+         */
+        $code = curl_getinfo($curl, CURLINFO_HTTP_CODE);
 		if (curl_errno($curl)) {
 			throw new Exception('Server error: ' . curl_error($curl));
 		}
-
-		if (strpos(curl_getinfo($curl, CURLINFO_CONTENT_TYPE), 'application/json') !== false) {
+        /**
+         * If JSON was returned, decode and return.
+         */
+		if (strpos($contentType, 'application/json') !== false) {
 			$payload = @json_decode($result, false, 128, JSON_BIGINT_AS_STRING); // intentionally @
 			if ($payload === false) {
 				throw new Exception('Invalid server response');
 			}
 		}
 
-		$code = curl_getinfo($curl, CURLINFO_HTTP_CODE);
 		if ($code >= 400) {
 			throw new Exception(
 				$payload->errors[0]->message ?? "Server error #$code with answer $result",
@@ -366,15 +408,59 @@ class Twitter
 		} elseif ($code === 204) {
 			$payload = true;
 		}
-
-		return $payload;
+        /**
+         * If the payload isn't null or undefined.
+         */
+        if (isset($payload)) {
+            return $payload;
+        }
+        /**
+         * There are instances where the Twitter API returns text/html or urlencoded responses.
+         * @link https://developer.twitter.com/en/docs/authentication/api-reference/request_token
+         * Convert the encoded URL to an Array and return it.
+         */
+        else if ($code === 200 &&
+            (strpos($contentType, 'application/x-www-form-urlencoded') !== false) ||
+            (strpos($contentType, 'text/html') !== false)) {
+            $res = array();
+            /**
+             * Process the url-encoded data and convert it into an array.
+             */
+            foreach (explode("&", $result) as $x) {
+                $y = explode("=", $x);
+                $res[$y[0]] = $y[1];
+            }
+            return $res;
+        }
+        else {
+            throw new Exception('Invalid server response (Not Valid)');
+        }
 	}
 
+    /**
+     * @param $oauth_callback | The Callback URL defined within your Application Settings
+     * @link https://developer.twitter.com/en/docs/apps/callback-urls
+     * @link https://developer.twitter.com/en/docs/authentication/api-reference/request_token
+     * @return array|bool|mixed
+     */
+    public function getRequestToken($oauth_callback) {
+        $resource = 'https://api.twitter.com/oauth/request_token';
+        try {
+            return $this->request($resource, 'POST', ['oauth_callback' => $oauth_callback]);
+        } catch (Exception $e) {
+            return false;
+        }
+    }
 
-	/**
-	 * Cached HTTP request.
-	 * @return stdClass|stdClass[]
-	 */
+    /**
+     * Cached HTTP request.
+     * @param string $resource
+     * @param array $data
+     * @param null $cacheExpire
+     * @return stdClass|stdClass[]
+     * @throws Exception
+     * @throws OAuth\Exception
+     */
 	public function cachedRequest(string $resource, array $data = [], $cacheExpire = null)
 	{
 		if (!self::$cacheDir) {
@@ -409,7 +495,6 @@ class Twitter
 			throw $e;
 		}
 	}
-
 
 	/**
 	 * Makes twitter links, @usernames and #hashtags clickable.
@@ -447,11 +532,7 @@ class Twitter
 	}
 }
 
-
-
 /**
  * An exception generated by Twitter.
  */
-class Exception extends \Exception
-{
-}
+class Exception extends \Exception {}

--- a/src/Twitter.php
+++ b/src/Twitter.php
@@ -468,10 +468,14 @@ class Twitter
         }
     }
 
-    public function invalidateToken($access_token, $access_token_secret) {
-        $resource = "https://api.twitter.com/oauth/invalidate_token";
+    /**
+     * @return array|bool|mixed|string
+     * @throws OAuth\Exception
+     */
+    public function invalidateAccessToken() {
+        $resource = "https://api.twitter.com/1.1/oauth/invalidate_token";
         try {
-            return $this->request($resource, 'POST', ['access_token' => $access_token, 'access_token_secret' => $access_token_secret]);
+            return $this->request($resource, 'POST', ['access_token' => $this->token->key, 'access_token_secret' => $this->token->secret]);
         } catch (Exception $e) {
             return $e->getMessage();
         }

--- a/src/Twitter.php
+++ b/src/Twitter.php
@@ -21,51 +21,51 @@ use stdClass;
  */
 class Twitter
 {
-	public const ME = 1;
-	public const ME_AND_FRIENDS = 2;
-	public const REPLIES = 3;
-	public const RETWEETS = 128; // include retweets?
+    public const ME = 1;
+    public const ME_AND_FRIENDS = 2;
+    public const REPLIES = 3;
+    public const RETWEETS = 128; // include retweets?
 
-	private const API_URL = 'https://api.twitter.com/1.1/';
+    private const API_URL = 'https://api.twitter.com/1.1/';
 
-	/** @var int */
-	public static $cacheExpire = '30 minutes';
+    /** @var int */
+    public static $cacheExpire = '30 minutes';
 
-	/** @var string */
-	public static $cacheDir;
+    /** @var string */
+    public static $cacheDir;
 
-	/** @var array */
-	public $httpOptions = [
-		CURLOPT_TIMEOUT => 20,
-		CURLOPT_SSL_VERIFYPEER => 0,
-		CURLOPT_USERAGENT => 'Twitter for PHP',
-	];
+    /** @var array */
+    public $httpOptions = [
+        CURLOPT_TIMEOUT => 20,
+        CURLOPT_SSL_VERIFYPEER => 0,
+        CURLOPT_USERAGENT => 'Twitter for PHP',
+    ];
 
-	/** @var OAuth\Consumer */
-	private $consumer;
+    /** @var OAuth\Consumer */
+    private $consumer;
 
-	/** @var OAuth\Token */
-	private $token;
+    /** @var OAuth\Token */
+    private $token;
 
-	/**
-	 * Creates object using consumer and access keys.
-	 * @throws Exception when CURL extension is not loaded
-	 */
-	public function __construct(
-		string $consumerKey,
-		string $consumerSecret,
-		string $accessToken = null,
-		string $accessTokenSecret = null
-	) {
-		if (!extension_loaded('curl')) {
-			throw new Exception('PHP extension CURL is not loaded.');
-		}
+    /**
+     * Creates object using consumer and access keys.
+     * @throws Exception when CURL extension is not loaded
+     */
+    public function __construct(
+        string $consumerKey,
+        string $consumerSecret,
+        string $accessToken = null,
+        string $accessTokenSecret = null
+    ) {
+        if (!extension_loaded('curl')) {
+            throw new Exception('PHP extension CURL is not loaded.');
+        }
 
-		$this->consumer = new OAuth\Consumer($consumerKey, $consumerSecret);
-		if ($accessToken && $accessTokenSecret) {
-			$this->token = new OAuth\Token($accessToken, $accessTokenSecret);
-		}
-	}
+        $this->consumer = new OAuth\Consumer($consumerKey, $consumerSecret);
+        if ($accessToken && $accessTokenSecret) {
+            $this->token = new OAuth\Token($accessToken, $accessTokenSecret);
+        }
+    }
 
     /**
      * Tests if user credentials are valid.
@@ -73,19 +73,19 @@ class Twitter
      * @throws Exception
      * @throws OAuth\Exception
      */
-	public function authenticate(): bool
-	{
-		try {
-			$res = $this->request('account/verify_credentials', 'GET');
-			return !empty($res->id);
+    public function authenticate(): bool
+    {
+        try {
+            $res = $this->request('account/verify_credentials', 'GET');
+            return !empty($res->id);
 
-		} catch (Exception $e) {
-			if ($e->getCode() === 401) {
-				return false;
-			}
-			throw $e;
-		}
-	}
+        } catch (Exception $e) {
+            if ($e->getCode() === 401) {
+                return false;
+            }
+            throw $e;
+        }
+    }
 
     /**
      * Sends message to the Twitter.
@@ -97,24 +97,24 @@ class Twitter
      * @throws Exception
      * @throws OAuth\Exception
      */
-	public function send(string $message, $mediaPath = null, array $options = []): stdClass
-	{
-		$mediaIds = [];
-		foreach ((array) $mediaPath as $item) {
-			$res = $this->request(
-				'https://upload.twitter.com/1.1/media/upload.json',
-				'POST',
-				[],
-				['media' => $item]
-			);
-			$mediaIds[] = $res->media_id_string;
-		}
-		return $this->request(
-			'statuses/update',
-			'POST',
-			$options + ['status' => $message, 'media_ids' => implode(',', $mediaIds) ?: null]
-		);
-	}
+    public function send(string $message, $mediaPath = null, array $options = []): stdClass
+    {
+        $mediaIds = [];
+        foreach ((array) $mediaPath as $item) {
+            $res = $this->request(
+                'https://upload.twitter.com/1.1/media/upload.json',
+                'POST',
+                [],
+                ['media' => $item]
+            );
+            $mediaIds[] = $res->media_id_string;
+        }
+        return $this->request(
+            'statuses/update',
+            'POST',
+            $options + ['status' => $message, 'media_ids' => implode(',', $mediaIds) ?: null]
+        );
+    }
 
     /**
      * Sends a direct message to the specified user.
@@ -125,20 +125,20 @@ class Twitter
      * @throws Exception
      * @throws OAuth\Exception
      */
-	public function sendDirectMessage(string $username, string $message): stdClass
-	{
-		return $this->request(
-			'direct_messages/events/new',
-			'JSONPOST',
-			['event' => [
-				'type' => 'message_create',
-				'message_create' => [
-					'target' => ['recipient_id' => $this->loadUserInfo($username)->id_str],
-					'message_data' => ['text' => $message],
-				],
-			]]
-		);
-	}
+    public function sendDirectMessage(string $username, string $message): stdClass
+    {
+        return $this->request(
+            'direct_messages/events/new',
+            'JSONPOST',
+            ['event' => [
+                'type' => 'message_create',
+                'message_create' => [
+                    'target' => ['recipient_id' => $this->loadUserInfo($username)->id_str],
+                    'message_data' => ['text' => $message],
+                ],
+            ]]
+        );
+    }
 
     /**
      * Follows a user on Twitter.
@@ -148,10 +148,10 @@ class Twitter
      * @throws Exception
      * @throws OAuth\Exception
      */
-	public function follow(string $username): stdClass
-	{
-		return $this->request('friendships/create', 'POST', ['screen_name' => $username]);
-	}
+    public function follow(string $username): stdClass
+    {
+        return $this->request('friendships/create', 'POST', ['screen_name' => $username]);
+    }
 
     /**
      * Returns the most recent statuses.
@@ -163,22 +163,22 @@ class Twitter
      * @throws Exception
      * @throws OAuth\Exception
      */
-	public function load(int $flags = self::ME, int $count = 20, array $data = null): array
-	{
-		static $timelines = [
-			self::ME => 'user_timeline',
-			self::ME_AND_FRIENDS => 'home_timeline',
-			self::REPLIES => 'mentions_timeline',
-		];
-		if (!isset($timelines[$flags & 3])) {
-			throw new \InvalidArgumentException;
-		}
+    public function load(int $flags = self::ME, int $count = 20, array $data = null): array
+    {
+        static $timelines = [
+            self::ME => 'user_timeline',
+            self::ME_AND_FRIENDS => 'home_timeline',
+            self::REPLIES => 'mentions_timeline',
+        ];
+        if (!isset($timelines[$flags & 3])) {
+            throw new \InvalidArgumentException;
+        }
 
-		return $this->cachedRequest('statuses/' . $timelines[$flags & 3], (array) $data + [
-			'count' => $count,
-			'include_rts' => $flags & self::RETWEETS ? 1 : 0,
-		]);
-	}
+        return $this->cachedRequest('statuses/' . $timelines[$flags & 3], (array) $data + [
+                'count' => $count,
+                'include_rts' => $flags & self::RETWEETS ? 1 : 0,
+            ]);
+    }
 
     /**
      * Returns information of a given user.
@@ -188,10 +188,10 @@ class Twitter
      * @throws Exception
      * @throws OAuth\Exception
      */
-	public function loadUserInfo(string $username): stdClass
-	{
-		return $this->cachedRequest('users/show', ['screen_name' => $username]);
-	}
+    public function loadUserInfo(string $username): stdClass
+    {
+        return $this->cachedRequest('users/show', ['screen_name' => $username]);
+    }
 
     /**
      * Returns information of a given user by id.
@@ -201,10 +201,10 @@ class Twitter
      * @throws Exception
      * @throws OAuth\Exception
      */
-	public function loadUserInfoById(string $id): stdClass
-	{
-		return $this->cachedRequest('users/show', ['user_id' => $id]);
-	}
+    public function loadUserInfoById(string $id): stdClass
+    {
+        return $this->cachedRequest('users/show', ['user_id' => $id]);
+    }
 
     /**
      * Returns IDs of followers of a given user.
@@ -217,18 +217,18 @@ class Twitter
      * @throws Exception
      * @throws OAuth\Exception
      */
-	public function loadUserFollowers(
-		string $username,
-		int $count = 5000,
-		int $cursor = -1,
-		$cacheExpiry = null
-	): stdClass {
-		return $this->cachedRequest('followers/ids', [
-			'screen_name' => $username,
-			'count' => $count,
-			'cursor' => $cursor,
-		], $cacheExpiry);
-	}
+    public function loadUserFollowers(
+        string $username,
+        int $count = 5000,
+        int $cursor = -1,
+               $cacheExpiry = null
+    ): stdClass {
+        return $this->cachedRequest('followers/ids', [
+            'screen_name' => $username,
+            'count' => $count,
+            'cursor' => $cursor,
+        ], $cacheExpiry);
+    }
 
     /**
      * Returns list of followers of a given user.
@@ -241,18 +241,18 @@ class Twitter
      * @throws Exception
      * @throws OAuth\Exception
      */
-	public function loadUserFollowersList(
-		string $username,
-		int $count = 200,
-		int $cursor = -1,
-		$cacheExpiry = null
-	): stdClass {
-		return $this->cachedRequest('followers/list', [
-			'screen_name' => $username,
-			'count' => $count,
-			'cursor' => $cursor,
-		], $cacheExpiry);
-	}
+    public function loadUserFollowersList(
+        string $username,
+        int $count = 200,
+        int $cursor = -1,
+               $cacheExpiry = null
+    ): stdClass {
+        return $this->cachedRequest('followers/list', [
+            'screen_name' => $username,
+            'count' => $count,
+            'cursor' => $cursor,
+        ], $cacheExpiry);
+    }
 
     /**
      * Destroys status.
@@ -261,11 +261,11 @@ class Twitter
      * @throws Exception
      * @throws OAuth\Exception
      */
-	public function destroy($id)
-	{
-		$res = $this->request("statuses/destroy/$id", 'POST', ['id' => $id]);
-		return $res->id ?: false;
-	}
+    public function destroy($id)
+    {
+        $res = $this->request("statuses/destroy/$id", 'POST', ['id' => $id]);
+        return $res->id ?: false;
+    }
 
     /**
      * Retrieves a single status.
@@ -274,11 +274,11 @@ class Twitter
      * @throws Exception
      * @throws OAuth\Exception
      */
-	public function get($id)
-	{
-		$res = $this->request("statuses/show/$id", 'GET');
-		return $res;
-	}
+    public function get($id)
+    {
+        $res = $this->request("statuses/show/$id", 'GET');
+        return $res;
+    }
 
     /**
      * Returns tweets that match a specified query.
@@ -289,11 +289,11 @@ class Twitter
      * @throws Exception
      * @throws OAuth\Exception
      */
-	public function search($query, bool $full = false)
-	{
-		$res = $this->request('search/tweets', 'GET', is_array($query) ? $query : ['q' => $query]);
-		return $full ? $res : $res->statuses;
-	}
+    public function search($query, bool $full = false)
+    {
+        $res = $this->request('search/tweets', 'GET', is_array($query) ? $query : ['q' => $query]);
+        return $full ? $res : $res->statuses;
+    }
 
     /**
      * Retrieves the top 50 trending topics for a specific WOEID.
@@ -302,10 +302,10 @@ class Twitter
      * @throws Exception
      * @throws OAuth\Exception
      */
-	public function getTrends(int $WOEID): array
-	{
-		return $this->request("trends/place.json?id=$WOEID", 'GET');
-	}
+    public function getTrends(int $WOEID): array
+    {
+        return $this->request("trends/place.json?id=$WOEID", 'GET');
+    }
 
     /**
      * Process HTTP request.
@@ -317,68 +317,68 @@ class Twitter
      * @throws Exception
      * @throws OAuth\Exception
      */
-	public function request(string $resource, string $method, array $data = [], array $files = [])
-	{
-		if (!strpos($resource, '://')) {
-			if (!strpos($resource, '.')) {
-				$resource .= '.json';
-			}
-			$resource = self::API_URL . $resource;
-		}
+    public function request(string $resource, string $method, array $data = [], array $files = [])
+    {
+        if (!strpos($resource, '://')) {
+            if (!strpos($resource, '.')) {
+                $resource .= '.json';
+            }
+            $resource = self::API_URL . $resource;
+        }
 
-		foreach ($data as $key => $val) {
-			if ($val === null) {
-				unset($data[$key]);
-			}
-		}
+        foreach ($data as $key => $val) {
+            if ($val === null) {
+                unset($data[$key]);
+            }
+        }
 
-		foreach ($files as $key => $file) {
-			if (!is_file($file)) {
-				throw new Exception("Cannot read the file $file. Check if file exists on disk and check its permissions.");
-			}
-			$data[$key] = new \CURLFile($file);
-		}
+        foreach ($files as $key => $file) {
+            if (!is_file($file)) {
+                throw new Exception("Cannot read the file $file. Check if file exists on disk and check its permissions.");
+            }
+            $data[$key] = new \CURLFile($file);
+        }
 
-		$headers = ['Expect:'];
+        $headers = ['Expect:'];
 
-		if ($method === 'JSONPOST') {
-			$method = 'POST';
-			$data = json_encode($data);
-			$headers[] = 'Content-Type: application/json';
+        if ($method === 'JSONPOST') {
+            $method = 'POST';
+            $data = json_encode($data);
+            $headers[] = 'Content-Type: application/json';
 
-		} elseif (($method === 'GET' || $method === 'DELETE') && $data) {
-			$resource .= '?' . http_build_query($data, '', '&');
-		}
+        } elseif (($method === 'GET' || $method === 'POST') && $data) {
+            $resource .= '?' . http_build_query($data, '', '&');
+        }
 
-		$request = OAuth\Request::from_consumer_and_token($this->consumer, $this->token, $method, $resource);
-		$request->sign_request(new OAuth\SignatureMethod_HMAC_SHA1, $this->consumer, $this->token);
-		$headers[] = $request->to_header();
+        $request = OAuth\Request::from_consumer_and_token($this->consumer, $this->token, $method, $resource);
+        $request->sign_request(new OAuth\SignatureMethod_HMAC_SHA1, $this->consumer, $this->token);
+        $headers[] = $request->to_header();
 
-		$options = [
-			CURLOPT_URL => $resource,
-			CURLOPT_HEADER => false,
-			CURLOPT_RETURNTRANSFER => true,
-			CURLOPT_HTTPHEADER => $headers,
-		] + $this->httpOptions;
+        $options = [
+                CURLOPT_URL => $resource,
+                CURLOPT_HEADER => false,
+                CURLOPT_RETURNTRANSFER => true,
+                CURLOPT_HTTPHEADER => $headers,
+            ] + $this->httpOptions;
 
-		if ($method === 'POST') {
-			$options += [
-				CURLOPT_POST => true,
-				CURLOPT_POSTFIELDS => $data,
-				CURLOPT_SAFE_UPLOAD => true,
-			];
-		} elseif ($method === 'DELETE') {
-			$options += [
-				CURLOPT_CUSTOMREQUEST => 'DELETE',
-			];
-		}
+        if ($method === 'POST') {
+            $options += [
+                CURLOPT_POST => true,
+                CURLOPT_POSTFIELDS => $data,
+                CURLOPT_SAFE_UPLOAD => true,
+            ];
+        } elseif ($method === 'DELETE') {
+            $options += [
+                CURLOPT_CUSTOMREQUEST => 'DELETE',
+            ];
+        }
 
-		$curl = curl_init();
-		curl_setopt_array($curl, $options);
+        $curl = curl_init();
+        curl_setopt_array($curl, $options);
         /**
          * The result of the request (Raw Body)
          */
-		$result = curl_exec($curl);
+        $result = curl_exec($curl);
         /**
          * Get the Content-Type from the Response;
          */
@@ -387,27 +387,27 @@ class Twitter
          * Get the Response Code from the Request.
          */
         $code = curl_getinfo($curl, CURLINFO_HTTP_CODE);
-		if (curl_errno($curl)) {
-			throw new Exception('Server error: ' . curl_error($curl));
-		}
+        if (curl_errno($curl)) {
+            throw new Exception('Server error: ' . curl_error($curl));
+        }
         /**
          * If JSON was returned, decode and return.
          */
-		if (strpos($contentType, 'application/json') !== false) {
-			$payload = @json_decode($result, false, 128, JSON_BIGINT_AS_STRING); // intentionally @
-			if ($payload === false) {
-				throw new Exception('Invalid server response');
-			}
-		}
+        if (strpos($contentType, 'application/json') !== false) {
+            $payload = @json_decode($result, false, 128, JSON_BIGINT_AS_STRING); // intentionally @
+            if ($payload === false) {
+                throw new Exception('Invalid server response');
+            }
+        }
 
-		if ($code >= 400) {
-			throw new Exception(
-				$payload->errors[0]->message ?? "Server error #$code with answer $result",
-				$code
-			);
-		} elseif ($code === 204) {
-			$payload = true;
-		}
+        if ($code >= 400) {
+            throw new Exception(
+                $payload->errors[0]->message ?? "Server error #$code with answer $result",
+                $code
+            );
+        } elseif ($code === 204) {
+            $payload = true;
+        }
         /**
          * If the payload isn't null or undefined.
          */
@@ -435,7 +435,7 @@ class Twitter
         else {
             throw new Exception('Invalid server response (Not Valid)');
         }
-	}
+    }
 
     /**
      * @param $oauth_callback | The Callback URL defined within your Application Settings
@@ -454,6 +454,30 @@ class Twitter
     }
 
     /**
+     * @param $oauth_token
+     * @param $oauth_verifier
+     * @return array|bool|mixed
+     * @throws OAuth\Exception
+     */
+    public function getAccessToken($oauth_token, $oauth_verifier) {
+        $resource = "https://api.twitter.com/oauth/access_token";
+        try {
+            return $this->request($resource, 'POST', ['oauth_verifier' => $oauth_verifier, 'oauth_token' => $oauth_token]);
+        } catch (Exception $e) {
+            return $e->getMessage();
+        }
+    }
+
+    public function invalidateToken($access_token, $access_token_secret) {
+        $resource = "https://api.twitter.com/oauth/invalidate_token";
+        try {
+            return $this->request($resource, 'POST', ['access_token' => $access_token, 'access_token_secret' => $access_token_secret]);
+        } catch (Exception $e) {
+            return $e->getMessage();
+        }
+    }
+
+    /**
      * Cached HTTP request.
      * @param string $resource
      * @param array $data
@@ -462,75 +486,75 @@ class Twitter
      * @throws Exception
      * @throws OAuth\Exception
      */
-	public function cachedRequest(string $resource, array $data = [], $cacheExpire = null)
-	{
-		if (!self::$cacheDir) {
-			return $this->request($resource, 'GET', $data);
-		}
-		if ($cacheExpire === null) {
-			$cacheExpire = self::$cacheExpire;
-		}
+    public function cachedRequest(string $resource, array $data = [], $cacheExpire = null)
+    {
+        if (!self::$cacheDir) {
+            return $this->request($resource, 'GET', $data);
+        }
+        if ($cacheExpire === null) {
+            $cacheExpire = self::$cacheExpire;
+        }
 
-		$cacheFile = self::$cacheDir
-			. '/twitter.'
-			. md5($resource . json_encode($data) . serialize([$this->consumer, $this->token]))
-			. '.json';
+        $cacheFile = self::$cacheDir
+            . '/twitter.'
+            . md5($resource . json_encode($data) . serialize([$this->consumer, $this->token]))
+            . '.json';
 
-		$cache = @json_decode((string) @file_get_contents($cacheFile)); // intentionally @
-		$expiration = is_string($cacheExpire)
-			? strtotime($cacheExpire) - time()
-			: $cacheExpire;
-		if ($cache && @filemtime($cacheFile) + $expiration > time()) { // intentionally @
-			return $cache;
-		}
+        $cache = @json_decode((string) @file_get_contents($cacheFile)); // intentionally @
+        $expiration = is_string($cacheExpire)
+            ? strtotime($cacheExpire) - time()
+            : $cacheExpire;
+        if ($cache && @filemtime($cacheFile) + $expiration > time()) { // intentionally @
+            return $cache;
+        }
 
-		try {
-			$payload = $this->request($resource, 'GET', $data);
-			file_put_contents($cacheFile, json_encode($payload));
-			return $payload;
+        try {
+            $payload = $this->request($resource, 'GET', $data);
+            file_put_contents($cacheFile, json_encode($payload));
+            return $payload;
 
-		} catch (Exception $e) {
-			if ($cache) {
-				return $cache;
-			}
-			throw $e;
-		}
-	}
+        } catch (Exception $e) {
+            if ($cache) {
+                return $cache;
+            }
+            throw $e;
+        }
+    }
 
-	/**
-	 * Makes twitter links, @usernames and #hashtags clickable.
-	 */
-	public static function clickable(stdClass $status): string
-	{
-		$all = [];
-		foreach ($status->entities->hashtags as $item) {
-			$all[$item->indices[0]] = ["https://twitter.com/search?q=%23$item->text", "#$item->text", $item->indices[1]];
-		}
-		foreach ($status->entities->urls as $item) {
-			if (!isset($item->expanded_url)) {
-				$all[$item->indices[0]] = [$item->url, $item->url, $item->indices[1]];
-			} else {
-				$all[$item->indices[0]] = [$item->expanded_url, $item->display_url, $item->indices[1]];
-			}
-		}
-		foreach ($status->entities->user_mentions as $item) {
-			$all[$item->indices[0]] = ["https://twitter.com/$item->screen_name", "@$item->screen_name", $item->indices[1]];
-		}
-		if (isset($status->entities->media)) {
-			foreach ($status->entities->media as $item) {
-				$all[$item->indices[0]] = [$item->url, $item->display_url, $item->indices[1]];
-			}
-		}
+    /**
+     * Makes twitter links, @usernames and #hashtags clickable.
+     */
+    public static function clickable(stdClass $status): string
+    {
+        $all = [];
+        foreach ($status->entities->hashtags as $item) {
+            $all[$item->indices[0]] = ["https://twitter.com/search?q=%23$item->text", "#$item->text", $item->indices[1]];
+        }
+        foreach ($status->entities->urls as $item) {
+            if (!isset($item->expanded_url)) {
+                $all[$item->indices[0]] = [$item->url, $item->url, $item->indices[1]];
+            } else {
+                $all[$item->indices[0]] = [$item->expanded_url, $item->display_url, $item->indices[1]];
+            }
+        }
+        foreach ($status->entities->user_mentions as $item) {
+            $all[$item->indices[0]] = ["https://twitter.com/$item->screen_name", "@$item->screen_name", $item->indices[1]];
+        }
+        if (isset($status->entities->media)) {
+            foreach ($status->entities->media as $item) {
+                $all[$item->indices[0]] = [$item->url, $item->display_url, $item->indices[1]];
+            }
+        }
 
-		krsort($all);
-		$s = $status->full_text ?? $status->text;
-		foreach ($all as $pos => $item) {
-			$s = iconv_substr($s, 0, $pos, 'UTF-8')
-				. '<a href="' . htmlspecialchars($item[0]) . '">' . htmlspecialchars($item[1]) . '</a>'
-				. iconv_substr($s, $item[2], iconv_strlen($s, 'UTF-8'), 'UTF-8');
-		}
-		return $s;
-	}
+        krsort($all);
+        $s = $status->full_text ?? $status->text;
+        foreach ($all as $pos => $item) {
+            $s = iconv_substr($s, 0, $pos, 'UTF-8')
+                . '<a href="' . htmlspecialchars($item[0]) . '">' . htmlspecialchars($item[1]) . '</a>'
+                . iconv_substr($s, $item[2], iconv_strlen($s, 'UTF-8'), 'UTF-8');
+        }
+        return $s;
+    }
 }
 
 /**

--- a/src/Twitter.php
+++ b/src/Twitter.php
@@ -228,7 +228,7 @@ class Twitter
 	 */
 	public function destroy($id)
 	{
-		$res = $this->request("statuses/destroy/$id", 'POST');
+		$res = $this->request("statuses/destroy/$id", 'POST', ['id' => $id]);
 		return $res->id ?: false;
 	}
 

--- a/src/Twitter.php
+++ b/src/Twitter.php
@@ -348,6 +348,8 @@ class Twitter
 
         } elseif (($method === 'GET' || $method === 'POST') && $data) {
             $resource .= '?' . http_build_query($data, '', '&');
+        } elseif ($method == 'AUTHPOST') {
+            $method = 'POST';
         }
 
         $request = OAuth\Request::from_consumer_and_token($this->consumer, $this->token, $method, $resource);
@@ -445,10 +447,11 @@ class Twitter
      * @link https://developer.twitter.com/en/docs/authentication/api-reference/request_token
      */
     public function getRequestToken($oauth_callback) {
-        $resource = 'https://api.twitter.com/oauth/request_token';
+        $resource = 'https://api.twitter.com/oauth/request_token?oauth_callback=' . urlencode($oauth_callback);
         try {
-            return $this->request($resource, 'POST', ['oauth_callback' => $oauth_callback]);
+            return $this->request($resource, 'AUTHPOST');
         } catch (Exception $e) {
+            print($e->getMessage());
             return false;
         }
     }

--- a/src/Twitter.php
+++ b/src/Twitter.php
@@ -54,8 +54,12 @@ class Twitter
 	 * Creates object using consumer and access keys.
 	 * @throws Exception when CURL extension is not loaded
 	 */
-	public function __construct(string $consumerKey, string $consumerSecret, string $accessToken = null, string $accessTokenSecret = null)
-	{
+	public function __construct(
+		string $consumerKey,
+		string $consumerSecret,
+		string $accessToken = null,
+		string $accessTokenSecret = null
+	) {
 		if (!extension_loaded('curl')) {
 			throw new Exception('PHP extension CURL is not loaded.');
 		}
@@ -196,8 +200,12 @@ class Twitter
 	 * https://dev.twitter.com/rest/reference/get/followers/ids
 	 * @throws Exception
 	 */
-	public function loadUserFollowers(string $username, int $count = 5000, int $cursor = -1, $cacheExpiry = null): stdClass
-	{
+	public function loadUserFollowers(
+		string $username,
+		int $count = 5000,
+		int $cursor = -1,
+		$cacheExpiry = null
+	): stdClass {
 		return $this->cachedRequest('followers/ids', [
 			'screen_name' => $username,
 			'count' => $count,
@@ -211,8 +219,12 @@ class Twitter
 	 * https://dev.twitter.com/rest/reference/get/followers/list
 	 * @throws Exception
 	 */
-	public function loadUserFollowersList(string $username, int $count = 200, int $cursor = -1, $cacheExpiry = null): stdClass
-	{
+	public function loadUserFollowersList(
+		string $username,
+		int $count = 200,
+		int $cursor = -1,
+		$cacheExpiry = null
+	): stdClass {
 		return $this->cachedRequest('followers/list', [
 			'screen_name' => $username,
 			'count' => $count,
@@ -347,9 +359,8 @@ class Twitter
 
 		$code = curl_getinfo($curl, CURLINFO_HTTP_CODE);
 		if ($code >= 400) {
-			throw new Exception(isset($payload->errors[0]->message)
-				? $payload->errors[0]->message
-				: "Server error #$code with answer $result",
+			throw new Exception(
+				$payload->errors[0]->message ?? "Server error #$code with answer $result",
 				$code
 			);
 		} elseif ($code === 204) {
@@ -379,7 +390,9 @@ class Twitter
 			. '.json';
 
 		$cache = @json_decode((string) @file_get_contents($cacheFile)); // intentionally @
-		$expiration = is_string($cacheExpire) ? strtotime($cacheExpire) - time() : $cacheExpire;
+		$expiration = is_string($cacheExpire)
+			? strtotime($cacheExpire) - time()
+			: $cacheExpire;
 		if ($cache && @filemtime($cacheFile) + $expiration > time()) { // intentionally @
 			return $cache;
 		}
@@ -424,7 +437,7 @@ class Twitter
 		}
 
 		krsort($all);
-		$s = isset($status->full_text) ? $status->full_text : $status->text;
+		$s = $status->full_text ?? $status->text;
 		foreach ($all as $pos => $item) {
 			$s = iconv_substr($s, 0, $pos, 'UTF-8')
 				. '<a href="' . htmlspecialchars($item[0]) . '">' . htmlspecialchars($item[1]) . '</a>'

--- a/src/Twitter.php
+++ b/src/Twitter.php
@@ -439,9 +439,10 @@ class Twitter
 
     /**
      * @param $oauth_callback | The Callback URL defined within your Application Settings
+     * @return array|bool|mixed
+     * @throws OAuth\Exception
      * @link https://developer.twitter.com/en/docs/apps/callback-urls
      * @link https://developer.twitter.com/en/docs/authentication/api-reference/request_token
-     * @return array|bool|mixed
      */
     public function getRequestToken($oauth_callback) {
         $resource = 'https://api.twitter.com/oauth/request_token';


### PR DESCRIPTION
The purpose of this pull-request is to use the existing infrastructure of this plugin to retrieve a request token from Twitter that can be used to generate 3-legged authentication flows. Some changes had to be made to the Request method in order to properly decode the response from twitter. (text/html)

I created a custom getRequestToken method to make it simple to retrieve an access token in array format that can then be passed back to the client side as JSON rather than a URL Encoded string.

 - Reference to issue: https://twittercommunity.com/t/why-is-the-return-type-of-post-oauth-request-token-text-html-when-it-is-clearly-not-html/698

Links:
 - https://developer.twitter.com/en/docs/authentication/api-reference/request_token
 - https://developer.twitter.com/en/docs/apps/callback-urls
 - https://developer.twitter.com/en/docs/authentication/api-reference/authorize

Changelog:
 - Refactored the Request Method to decode and return an array from Twitter responses that are formatted as `text/html` and `application/x-www-form-urlencoded` - `POST oauth/request_token`.
 - Added a method that utilizes the existing Request Method and retrieves an oauth request token from twitter to be used for 3-legged authentication.
 - Revised Readme with examples on how to use the new method.
 - Updated PhpDoc and some cleanup.