### PR TITLE
Making adjustments to allow operation w/ API 2

### DIFF
--- a/examples/custom-request.php
+++ b/examples/custom-request.php
@@ -16,11 +16,11 @@ $statuses = $twitter->request('statuses/retweets_of_me', 'GET');
 <title>Twitter retweets of me</title>
 
 <ul>
-<?php foreach ($statuses as $status): ?>
+<?php foreach ($statuses as $status) { ?>
 	<li><a href="http://twitter.com/<?php echo $status->user->screen_name ?>"><img src="<?php echo htmlspecialchars($status->user->profile_image_url_https) ?>">
 		<?php echo htmlspecialchars($status->user->name) ?></a>:
 		<?php echo Twitter::clickable($status) ?>
 		<small>at <?php echo date('j.n.Y H:i', strtotime($status->created_at)) ?></small>
 	</li>
-<?php endforeach ?>
+<?php } ?>
 </ul>

--- a/examples/load.php
+++ b/examples/load.php
@@ -19,11 +19,11 @@ $statuses = $twitter->load(Twitter::ME_AND_FRIENDS);
 <title>Twitter timeline demo</title>
 
 <ul>
-<?php foreach ($statuses as $status): ?>
+<?php foreach ($statuses as $status) { ?>
 	<li><a href="https://twitter.com/<?php echo $status->user->screen_name ?>"><img src="<?php echo htmlspecialchars($status->user->profile_image_url_https) ?>">
 		<?php echo htmlspecialchars($status->user->name) ?></a>:
 		<?php echo Twitter::clickable($status) ?>
 		<small>at <?php echo date('j.n.Y H:i', strtotime($status->created_at)) ?></small>
 	</li>
-<?php endforeach ?>
+<?php } ?>
 </ul>

--- a/examples/search.php
+++ b/examples/search.php
@@ -16,11 +16,11 @@ $results = $twitter->search('#nette');
 <title>Twitter search demo</title>
 
 <ul>
-<?php foreach ($results as $status): ?>
+<?php foreach ($results as $status) { ?>
 	<li><a href="https://twitter.com/<?php echo $status->user->screen_name ?>"><img src="<?php echo htmlspecialchars($status->user->profile_image_url_https) ?>">
 		<?php echo htmlspecialchars($status->user->name) ?></a>:
 		<?php echo Twitter::clickable($status) ?>
 		<small>at <?php echo date('j.n.Y H:i', strtotime($status->created_at)) ?></small>
 	</li>
-<?php endforeach ?>
+<?php } ?>
 </ul>

--- a/readme.md
+++ b/readme.md
@@ -116,12 +116,18 @@ if (!$twitter->authenticate()) {
 Other commands
 --------------
 
-You can use all commands defined by [Twitter API 1.1](https://dev.twitter.com/rest/public).
+You can use all commands defined by [Twitter API](https://dev.twitter.com/rest/public).
 For example [GET statuses/retweets_of_me](https://dev.twitter.com/rest/reference/get/statuses/retweets_of_me)
 returns the array of most recent tweets authored by the authenticating user:
 
 ```php
 $statuses = $twitter->request('statuses/retweets_of_me', 'GET', ['count' => 20]);
+```
+
+You can also specify which API version to use with the API_*_SUFFIX constants:
+
+```php
+$statuses = $twitter->request('tweets', 'GET', [], [], Twitter::API_2_SUFFIX);
 ```
 
 Changelog

--- a/readme.md
+++ b/readme.md
@@ -6,13 +6,21 @@
 Twitter for PHP is a very small and easy-to-use library for sending
 messages to Twitter and receiving status updates.
 
-If you like this, **[please make a donation now](https://nette.org/make-donation?to=twitter-php)**. Thank you!
-
 It requires PHP 5.4 or newer with CURL extension and is licensed under the New BSD License.
 You can obtain the latest version from our [GitHub repository](https://github.com/dg/twitter-php)
 or install it via Composer:
 
 	composer require dg/twitter-php
+
+
+[Support Me](https://github.com/sponsors/dg)
+--------------------------------------------
+
+Do you like Nette DI? Are you looking forward to the new features?
+
+[![Buy me a coffee](https://files.nette.org/icons/donation-3.svg)](https://github.com/sponsors/dg)
+
+Thank you!
 
 
 Usage

--- a/src/OAuth.php
+++ b/src/OAuth.php
@@ -302,12 +302,18 @@ class Request
 	/**
 	 * attempt to build up a request from what was passed to the server
 	 */
-	public static function from_request(string $http_method = null, string $http_url = null, array $parameters = null): self
+	public static function from_request(
+		string $http_method = null,
+		string $http_url = null,
+		array $parameters = null
+	): self
 	{
 		$scheme = (!isset($_SERVER['HTTPS']) || $_SERVER['HTTPS'] != 'on')
 			? 'http'
 			: 'https';
-		$http_url = ($http_url) ? $http_url : $scheme .
+		$http_url = ($http_url)
+			? $http_url
+			: $scheme .
 			'://' . $_SERVER['HTTP_HOST'] .
 			':' .
 			$_SERVER['SERVER_PORT'] .
@@ -339,7 +345,10 @@ class Request
 
 			// We have a Authorization-header with OAuth data. Parse the header
 			// and add those overriding any duplicates from GET or POST
-			if (isset($request_headers['Authorization']) && substr($request_headers['Authorization'], 0, 6) == 'OAuth ') {
+			if (
+				isset($request_headers['Authorization'])
+				&& substr($request_headers['Authorization'], 0, 6) == 'OAuth '
+			) {
 				$header_parameters = Util::split_header(
 					$request_headers['Authorization']
 				);
@@ -354,7 +363,13 @@ class Request
 	/**
 	 * pretty much a helper function to set up the request
 	 */
-	public static function from_consumer_and_token(Consumer $consumer, ?Token $token, string $http_method, string $http_url, array $parameters = null): self
+	public static function from_consumer_and_token(
+		Consumer $consumer,
+		?Token $token,
+		string $http_method,
+		string $http_url,
+		array $parameters = null
+	): self
 	{
 		$parameters = $parameters ?: [];
 		$defaults = [
@@ -392,7 +407,7 @@ class Request
 
 	public function get_parameter(string $name)
 	{
-		return isset($this->parameters[$name]) ? $this->parameters[$name] : null;
+		return $this->parameters[$name] ?? null;
 	}
 
 
@@ -465,7 +480,9 @@ class Request
 		$parts = parse_url($this->http_url);
 
 		$scheme = (isset($parts['scheme'])) ? $parts['scheme'] : 'http';
-		$port = (isset($parts['port'])) ? $parts['port'] : (($scheme == 'https') ? '443' : '80');
+		$port = (isset($parts['port']))
+			? $parts['port']
+			: (($scheme == 'https') ? '443' : '80');
 		$host = (isset($parts['host'])) ? $parts['host'] : '';
 		$path = (isset($parts['path'])) ? $parts['path'] : '';
 
@@ -581,7 +598,7 @@ class Util
 	public static function urlencode_rfc3986($input)
 	{
 		if (is_array($input)) {
-			return array_map([__CLASS__, 'urlencode_rfc3986'], $input);
+			return array_map([self::class, 'urlencode_rfc3986'], $input);
 		} elseif (is_scalar($input)) {
 			return str_replace('+', ' ', str_replace('%7E', '~', rawurlencode((string) $input)));
 		} else {

--- a/src/Twitter.php
+++ b/src/Twitter.php
@@ -228,7 +228,7 @@ class Twitter
 	 */
 	public function destroy($id)
 	{
-		$res = $this->request("statuses/destroy/$id", 'POST');
+		$res = $this->request("statuses/destroy/$id", 'POST', ['id' => $id]);
 		return $res->id ?: false;
 	}
 

--- a/src/Twitter.php
+++ b/src/Twitter.php
@@ -54,8 +54,12 @@ class Twitter
 	 * Creates object using consumer and access keys.
 	 * @throws Exception when CURL extension is not loaded
 	 */
-	public function __construct(string $consumerKey, string $consumerSecret, string $accessToken = null, string $accessTokenSecret = null)
-	{
+	public function __construct(
+		string $consumerKey,
+		string $consumerSecret,
+		string $accessToken = null,
+		string $accessTokenSecret = null
+	) {
 		if (!extension_loaded('curl')) {
 			throw new Exception('PHP extension CURL is not loaded.');
 		}
@@ -196,7 +200,12 @@ class Twitter
 	 * https://dev.twitter.com/rest/reference/get/followers/ids
 	 * @throws Exception
 	 */
-	public function loadUserFollowers(string $username, int $count = 5000, int $cursor = -1, $cacheExpiry = null): stdClass
+	public function loadUserFollowers(
+		string $username,
+		int $count = 5000,
+		int $cursor = -1,
+		$cacheExpiry = null
+	): stdClass
 	{
 		return $this->cachedRequest('followers/ids', [
 			'screen_name' => $username,
@@ -211,7 +220,12 @@ class Twitter
 	 * https://dev.twitter.com/rest/reference/get/followers/list
 	 * @throws Exception
 	 */
-	public function loadUserFollowersList(string $username, int $count = 200, int $cursor = -1, $cacheExpiry = null): stdClass
+	public function loadUserFollowersList(
+		string $username,
+		int $count = 200,
+		int $cursor = -1,
+		$cacheExpiry = null
+	): stdClass
 	{
 		return $this->cachedRequest('followers/list', [
 			'screen_name' => $username,
@@ -347,9 +361,8 @@ class Twitter
 
 		$code = curl_getinfo($curl, CURLINFO_HTTP_CODE);
 		if ($code >= 400) {
-			throw new Exception(isset($payload->errors[0]->message)
-				? $payload->errors[0]->message
-				: "Server error #$code with answer $result",
+			throw new Exception(
+				$payload->errors[0]->message ?? "Server error #$code with answer $result",
 				$code
 			);
 		} elseif ($code === 204) {
@@ -379,7 +392,9 @@ class Twitter
 			. '.json';
 
 		$cache = @json_decode((string) @file_get_contents($cacheFile)); // intentionally @
-		$expiration = is_string($cacheExpire) ? strtotime($cacheExpire) - time() : $cacheExpire;
+		$expiration = is_string($cacheExpire)
+			? strtotime($cacheExpire) - time()
+			: $cacheExpire;
 		if ($cache && @filemtime($cacheFile) + $expiration > time()) { // intentionally @
 			return $cache;
 		}
@@ -424,7 +439,7 @@ class Twitter
 		}
 
 		krsort($all);
-		$s = isset($status->full_text) ? $status->full_text : $status->text;
+		$s = $status->full_text ?? $status->text;
 		foreach ($all as $pos => $item) {
 			$s = iconv_substr($s, 0, $pos, 'UTF-8')
 				. '<a href="' . htmlspecialchars($item[0]) . '">' . htmlspecialchars($item[1]) . '</a>'


### PR DESCRIPTION
Adjusted `Twitter::request(..)` to allow users the ability to query Twitter API v1.1 & v2:

* Created `Twitter::makeApiUrl(..)` method for joining versioned API resource paths
* Added `$apiSuffix` parameter to `Twitter::request(..)` for specifying Twitter API version suffix
* Modified `Twitter::request(..)` logic to exclude '.json' append for API v2 paths
* Modified `Twitter::request(..)` to use `Twitter::makeApiUrl(..)` for incomplete API paths
* Modified code-docs for `Twitter::request(..)` to provide more information
* Modified `readme.md` to note that API v2 requests are possible

Tested both of the following requests with my own keys to ensure they worked:

```php
$statuses = $twitter->request('tweets', 'GET', ['ids' => '???'], [], Twitter::API_2_SUFFIX);
$statuses = $twitter->request('statuses/retweets_of_me', 'GET', ['count' => 20]);
```